### PR TITLE
Update provider-Voxtelesys.php

### DIFF
--- a/providers/provider-Voxtelesys.php
+++ b/providers/provider-Voxtelesys.php
@@ -27,7 +27,7 @@ class Voxtelesys extends providerBase
     {
         $req = array(
             'from'  => '+'.$from,
-            'to'    => '+'.$to,
+            'to'    => ['+'.$to],
             'media' => $this->media_urls($id)
         );
         if ($message)
@@ -42,7 +42,7 @@ class Voxtelesys extends providerBase
     {
         $req = array(
             'from'  => '+'.$from,
-            'to'    => '+'.$to,
+            'to'    => ['+'.$to],
             'body'  => $message
         );
         $this->sendVoxtelesys($req, $id);


### PR DESCRIPTION
by adding the brackets within the to fixes error of the to not being in a array
        $req = array(
            'from'  => '+'.$from,
            'to'    => ['+'.$to],
            'media' => $this->media_urls($id)

    public function sendMessage($id, $to, $from, $message=null)
    {
        $req = array(
            'from'  => '+'.$from,
            'to'    => ['+'.$to],
            'body'  => $message

I have tested this error is now gone and message sends. Error thrown before change was  sms connector Server Error: Unable to send message: HTTP 422, {"status":"error","error":"to must be an array"}