### PR TITLE
Adding bandwidth and updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ a generic, expandable connector, with new providers added as contributed by the 
 
 ### Providers
 
+* Bandwidth: Messaging API v2 (https://dev.bandwidth.com/apis/messaging/) (Doesn't currently support status callbacks)
 * Bulk Solutions (Bulkvs): API v1 (https://portal.bulkvs.com/api/v1.0/documentation)
 * Commio/Thinq: (https://apidocs.thinq.com/#bac2ace6-7777-47d8-931e-495b62f01799)
 * Flowroute: Messaging API v2.2, webhook v2.1 (https://developer.flowroute.com/api/messages/v2.2/)

--- a/Smsconnector.class.php
+++ b/Smsconnector.class.php
@@ -787,6 +787,7 @@ class Smsconnector extends FreePBX_Helpers implements BMO
 				case 'showuser':
 					$sipSmsEnabled 	  = null;
 					$defaultDid       = null;
+					$emailOffline	  = null;
 
 					if(isset($request['user']))
 					{
@@ -795,7 +796,6 @@ class Smsconnector extends FreePBX_Helpers implements BMO
 						$defaultDid    = $this->Userman->getModuleSettingByID($user['id'],'smsconnector','sipsmsdefaultdid',true);
 						$emailOffline  = $this->Userman->getModuleSettingById($user['id'],'smsconnector','sipsmsemailoffline',true);
 					}
-
 					return array(
 						array(
 							'title' => _('SMS Connector'),
@@ -805,7 +805,7 @@ class Smsconnector extends FreePBX_Helpers implements BMO
 								'sipsmsenabled' => $sipSmsEnabled,
 								'sipsmsdefaultdid' => $defaultDid,
 								'sipsmsemailoffline' => $emailOffline,
-								'dids' => $this->getDidsByUser($request['user'])
+								'dids' => !empty($request['user']) ? $this->getDidsByUser($request['user']) : array()
 							)),
 						)
 					);

--- a/adaptor/Smsconnector.class.php
+++ b/adaptor/Smsconnector.class.php
@@ -107,7 +107,7 @@ class Smsconnector extends \FreePBX\modules\Sms\AdaptorBase {
         return $row->providerid;
 	}
 
-    public function dialPlanHooks(&$ext, $engine, $priority)
+    public function dialPlanHooks(&$ext, $engine, $priority): void
     {
         if ($engine != "asterisk") { return; }
         $section = 'smsconnector-messages';

--- a/providers/provider-Bandwidth.php
+++ b/providers/provider-Bandwidth.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace FreePBX\modules\Smsconnector\Provider;
+
+class Bandwidth extends providerBase
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->name       = _('Bandwidth');
+        $this->nameRaw    = 'bandwidth';
+        $this->APIUrlInfo = 'https://dev.bandwidth.com/apis/messaging/';
+        $this->APIVersion = 'v2.0';
+
+        $this->configInfo = array(
+            'api_token' => array(
+                'type'      => 'string',
+                'label'     => _('API Token'),
+                'help'      => _("Enter the Bandwidth API Token"),
+                'default'   => '',
+                'required'  => true,
+                'placeholder' => _('Enter API Token'),
+            ),
+            'api_secret' => array(
+                'type'      => 'string',
+                'label'     => _('API Secret'),
+                'help'      => _("Enter the Bandwidth API Secret"),
+                'default'   => '',
+                'required'  => true,
+                'class'     => 'confidential',
+                'placeholder' => _('Enter API Secret'),
+            ),
+            'account_id' => array(
+                'type'      => 'string',
+                'label'     => _('Account ID'),
+                'help'      => _("Enter the Bandwidth Account ID (7 numbers)"),
+                'default'   => '',
+                'required'  => true,
+                'placeholder' => _('Enter Account ID'),
+            ),
+            'application_id' => array(
+                'type'      => 'string',
+                'label'     => _('Application ID'),
+                'help'      => _("Enter the Bandwidth Application ID"),
+                'default'   => '',
+                'required'  => true,
+                'placeholder' => _('Enter Application ID'),
+            ),
+            'callback_user_id' => array(
+                'type'      => 'string',
+                'label'     => _('Callback User ID'),
+                'help'      => _("Enter the Callback User ID (optional)"),
+                'default'   => '',
+                'required'  => false,
+                'placeholder' => _('Enter Callback User ID (optional)'),
+            ),
+            'callback_password' => array(
+                'type'      => 'string',
+                'label'     => _('Callback Password'),
+                'help'      => _("Enter the Callback Password (optional)"),
+                'default'   => '',
+                'required'  => false,
+                'class'     => 'confidential',
+                'placeholder' => _('Enter Callback Password (optional)'),
+            )
+        );
+    }
+
+    public function sendMedia($id, $to, $from, $message = null)
+    {
+        $req = array(
+            "applicationId" => $this->getConfig($this->nameRaw)['application_id'],
+            "to"    => array($to),
+            "from"  => $from,
+            "media" => $this->media_urls($id)
+        );
+        if ($message) {
+            $attr['text'] = $message;
+        }
+
+        $this->sendBandwidth($req, $id);
+        return true;
+    }
+
+    public function sendMessage($id, $to, $from, $message = null)
+    {
+        $req = array(
+            "applicationId" => $this->getConfig($this->nameRaw)['application_id'],
+            "to"    => array($to),
+            "from"  => $from,
+            "text"  => $message
+        );
+        $this->SendBandwidth($req, $id);
+        return true;
+    }
+
+    private function sendBandwidth($payload, $mid)
+    {
+        $config = $this->getConfig($this->nameRaw);
+
+        $headers = array(
+            "Content-Type" => "application/json",
+            "Authorization" => "Basic " . base64_encode($config['api_token'] . ":" . $config['api_secret'])
+        );
+        $url = "https://messaging.bandwidth.com/api/v2/users/" . $config['account_id'] . "/messages";
+        $json = json_encode($payload);
+        $session = \FreePBX::Curl()->requests($url);
+
+        try {
+            $bandwidthResponse = $session->post('', $headers, $json, array());
+            freepbx_log(FPBX_LOG_INFO, sprintf("%s responds: HTTP %s, %s", $this->nameRaw, $bandwidthResponse->status_code, $bandwidthResponse->body), true);
+
+            if (!$bandwidthResponse->success) {
+                throw new \Exception("HTTP $bandwidthResponse->status_code, $bandwidthResponse->body");
+            }
+            $this->setDelivered($mid);
+        } catch (\Exception $e) {
+            throw new \Exception('Unable to send message: ' . $e->getMessage());
+        }
+    }
+
+    public function callPublic($connector)
+    {
+        $config = $this->getConfig($this->nameRaw);
+
+        // Check if callback authentication is enabled/expected
+        // If it is, check that the user and password match the values coming from bandwidth
+        if ($config['callback_user_id'] && $config['callback_password']) {
+            
+            $user = $_SERVER['PHP_AUTH_USER'];
+            $password = $_SERVER['PHP_AUTH_PW'];
+            
+            if (!$user || !$password || $user !== $config['callback_user_id'] || $password !== $config['callback_password']) {
+                freepbx_log(FPBX_LOG_INFO, sprintf("Callback authentication failed for %s", $this->nameRaw));
+                freepbx_log(FPBX_LOG_INFO, sprintf("From Bandwidth. Pass: %s, User: %s", $password, $user));
+                freepbx_log(FPBX_LOG_INFO, sprintf("Expected pass: %s, Expected user: %s", $config['callback_password'], $config['callback_user_id']));
+                return 401;
+            }
+        }
+
+        if ($_SERVER['REQUEST_METHOD'] !== "POST") {
+            return 405;
+        }
+
+        $postdata = file_get_contents("php://input");
+        $sms      = json_decode($postdata)[0];
+
+        freepbx_log(FPBX_LOG_INFO, sprintf("Webhook (%s) in: %s", $this->nameRaw, print_r($postdata, true)));
+
+        if (empty($sms)) {
+            return 403;
+        }
+
+        if (isset($sms)) {
+            if (isset($sms->type) && ($sms->type == 'message-received')) {
+
+                $from = ltrim($sms->message->from, '+'); // strip + if exists
+                $to   = ltrim($sms->to, '+'); // The sms->to will always just be one number, but if we wanted to support group messaging we'd need to look at sms->message->to which holds an array of all numbers in the convo
+                $text = $sms->message->text;
+                $emid = $sms->message->id;
+
+                try {
+                    $msgid = $connector->getMessage($to, $from, '', $text, null, null, $emid);
+                } catch (\Exception $e) {
+                    throw new \Exception(sprintf('Unable to get message: %s', $e->getMessage())); 
+                }
+
+                if (isset($sms->message->media[0])) {
+                    // Create authentication header/context required to grab media from Bandwidth
+                    $context = stream_context_create([
+                        "http" => [
+                            "header" => "Authorization: Basic " . base64_encode($config['api_token'] . ":" . $config['api_secret'])
+                        ]
+                    ]);
+
+                    foreach ($sms->message->media as $media) {
+                        $img = file_get_contents($media, false, $context);
+                        $purl = parse_url($media);
+                        $name = $msgid . basename($purl['path']);
+
+                        try {
+                            $connector->addMedia($msgid, $name, $img);
+                        } catch (\Exception $e) {
+                            throw new \Exception(sprintf('Unable to store MMS media: %s', $e->getMessage()));
+                        }
+                    }
+                }
+
+                $connector->emitSmsInboundUserEvt($msgid, $to, $from, '', $text, null, 'Smsconnector', $emid);
+            } else if (isset($sms->type)) {
+                // Likely a callback for delivery status
+                // See https://dev.bandwidth.com/docs/messaging/webhooks/
+                // These can be disabled when setting up the application within Bandwidth
+                // It would be good to support these in the future
+                // We still reply with a 202 to appease Bandwidth
+                freepbx_log(FPBX_LOG_INFO, sprintf("Incoming message of unknown type %s. Contents: %s", $sms->type, print_r($sms, true)));
+            }
+        }
+
+        return 202;
+    }
+}

--- a/providers/provider-Bandwidth.php
+++ b/providers/provider-Bandwidth.php
@@ -69,10 +69,10 @@ class Bandwidth extends providerBase
     public function sendMedia($id, $to, $from, $message = null)
     {
         $req = array(
-            "applicationId" => $this->getConfig($this->nameRaw)['application_id'],
-            "to"    => array($to),
-            "from"  => $from,
-            "media" => $this->media_urls($id)
+            'applicationId' => $this->getConfig($this->nameRaw)['application_id'],
+            'to'    => array($to),
+            'from'  => $from,
+            'media' => $this->media_urls($id)
         );
         if ($message) {
             $attr['text'] = $message;
@@ -85,10 +85,10 @@ class Bandwidth extends providerBase
     public function sendMessage($id, $to, $from, $message = null)
     {
         $req = array(
-            "applicationId" => $this->getConfig($this->nameRaw)['application_id'],
-            "to"    => array($to),
-            "from"  => $from,
-            "text"  => $message
+            'applicationId' => $this->getConfig($this->nameRaw)['application_id'],
+            'to'    => array($to),
+            'from'  => $from,
+            'text'  => $message
         );
         $this->SendBandwidth($req, $id);
         return true;
@@ -108,14 +108,14 @@ class Bandwidth extends providerBase
 
         try {
             $bandwidthResponse = $session->post('', $headers, $json, array());
-            freepbx_log(FPBX_LOG_INFO, sprintf("%s responds: HTTP %s, %s", $this->nameRaw, $bandwidthResponse->status_code, $bandwidthResponse->body), true);
+            freepbx_log(FPBX_LOG_INFO, sprintf(_('%s responds: HTTP %s, %s'), $this->nameRaw, $bandwidthResponse->status_code, $bandwidthResponse->body), true);
 
             if (!$bandwidthResponse->success) {
-                throw new \Exception("HTTP $bandwidthResponse->status_code, $bandwidthResponse->body");
+                throw new \Exception(sprintf(_('HTTP %s, %s'), $bandwidthResponse->status_code, $bandwidthResponse->body));
             }
             $this->setDelivered($mid);
         } catch (\Exception $e) {
-            throw new \Exception('Unable to send message: ' . $e->getMessage());
+            throw new \Exception(_('Unable to send message: ') . $e->getMessage());
         }
     }
 
@@ -125,15 +125,14 @@ class Bandwidth extends providerBase
 
         // Check if callback authentication is enabled/expected
         // If it is, check that the user and password match the values coming from bandwidth
-        if ($config['callback_user_id'] && $config['callback_password']) {
+        if (!empty($config['callback_user_id']) && !empty($config['callback_password'])) {
             
-            $user = $_SERVER['PHP_AUTH_USER'];
-            $password = $_SERVER['PHP_AUTH_PW'];
+            $user = (empty($_SERVER['PHP_AUTH_USER'])) ? '' : $_SERVER['PHP_AUTH_USER'];
+            $password = (empty($_SERVER['PHP_AUTH_PW'])) ? '' : $_SERVER['PHP_AUTH_PW'];
             
             if (!$user || !$password || $user !== $config['callback_user_id'] || $password !== $config['callback_password']) {
-                freepbx_log(FPBX_LOG_INFO, sprintf("Callback authentication failed for %s", $this->nameRaw));
-                freepbx_log(FPBX_LOG_INFO, sprintf("From Bandwidth. Pass: %s, User: %s", $password, $user));
-                freepbx_log(FPBX_LOG_INFO, sprintf("Expected pass: %s, Expected user: %s", $config['callback_password'], $config['callback_user_id']));
+                freepbx_log(FPBX_LOG_INFO, sprintf(_('Callback authentication failed for %s'), $this->nameRaw));
+                freepbx_log(FPBX_LOG_INFO, sprintf(_('From Bandwidth. Pass: %s, User: %s'), $password, $user));
                 return 401;
             }
         }
@@ -145,7 +144,7 @@ class Bandwidth extends providerBase
         $postdata = file_get_contents("php://input");
         $sms      = json_decode($postdata)[0];
 
-        freepbx_log(FPBX_LOG_INFO, sprintf("Webhook (%s) in: %s", $this->nameRaw, print_r($postdata, true)));
+        freepbx_log(FPBX_LOG_INFO, sprintf(_('Webhook (%s) in: %s'), $this->nameRaw, print_r($postdata, true)));
 
         if (empty($sms)) {
             return 403;
@@ -162,7 +161,7 @@ class Bandwidth extends providerBase
                 try {
                     $msgid = $connector->getMessage($to, $from, '', $text, null, null, $emid);
                 } catch (\Exception $e) {
-                    throw new \Exception(sprintf('Unable to get message: %s', $e->getMessage())); 
+                    throw new \Exception(sprintf(_('Unable to get message: %s'), $e->getMessage())); 
                 }
 
                 if (isset($sms->message->media[0])) {
@@ -181,7 +180,7 @@ class Bandwidth extends providerBase
                         try {
                             $connector->addMedia($msgid, $name, $img);
                         } catch (\Exception $e) {
-                            throw new \Exception(sprintf('Unable to store MMS media: %s', $e->getMessage()));
+                            throw new \Exception(sprintf(_('Unable to store MMS media: %s'), $e->getMessage()));
                         }
                     }
                 }
@@ -193,7 +192,7 @@ class Bandwidth extends providerBase
                 // These can be disabled when setting up the application within Bandwidth
                 // It would be good to support these in the future
                 // We still reply with a 202 to appease Bandwidth
-                freepbx_log(FPBX_LOG_INFO, sprintf("Incoming message of unknown type %s. Contents: %s", $sms->type, print_r($sms, true)));
+                freepbx_log(FPBX_LOG_INFO, sprintf(_('Incoming message of unknown type %s. Contents: %s'), $sms->type, print_r($sms, true)));
             }
         }
 

--- a/providers/provider-Bulkvs.php
+++ b/providers/provider-Bulkvs.php
@@ -58,7 +58,7 @@ class Bulkvs extends providerBase
         return true;
     }
 
-    private function sendBulkvs($payload, $mid)
+    private function sendBulkvs($payload, $mid): void
     {
         $config = $this->getConfig($this->nameRaw);
 

--- a/providers/provider-Commio.php
+++ b/providers/provider-Commio.php
@@ -66,7 +66,7 @@ class Commio extends providerBase
         return true;
     }
 
-    private function sendCommio($payload, $mid, $msgType = 'sms')
+    private function sendCommio($payload, $mid, $msgType = 'sms'): void
     {
         $config = $this->getConfig($this->nameRaw);
 

--- a/providers/provider-Flowroute.php
+++ b/providers/provider-Flowroute.php
@@ -70,7 +70,7 @@ class Flowroute extends providerBase
         return true;
     }
 
-    private function sendFlowroute($payload, $mid)
+    private function sendFlowroute($payload, $mid): void
     {
         $config = $this->getConfig($this->nameRaw);
 

--- a/providers/provider-Signalwire.php
+++ b/providers/provider-Signalwire.php
@@ -72,7 +72,7 @@ class Signalwire extends providerBase
         return true;
     }
 
-    private function sendSignalwire($payload, $mid)
+    private function sendSignalwire($payload, $mid): void
     {
         $config = $this->getConfig($this->nameRaw);
 

--- a/providers/provider-Sinch.php
+++ b/providers/provider-Sinch.php
@@ -60,7 +60,7 @@ class Sinch extends providerBase
         return true;
     }
 
-    private function sendSinch($payload, $mid)
+    private function sendSinch($payload, $mid): void
     {
         $config = $this->getConfig($this->nameRaw);
 

--- a/providers/provider-Siptrunk.php
+++ b/providers/provider-Siptrunk.php
@@ -71,7 +71,7 @@ class Siptrunk extends providerBase
         return true;
     }
 
-    private function sendSiptrunk($payload, $mid)
+    private function sendSiptrunk($payload, $mid): void
     {
         $config = $this->getConfig($this->nameRaw);
 

--- a/providers/provider-Skyetel.php
+++ b/providers/provider-Skyetel.php
@@ -53,7 +53,7 @@ class Skyetel extends providerBase
         return true;
     }
 
-    private function sendSkyetel($payload, $from, $mid)
+    private function sendSkyetel($payload, $from, $mid): void
     {
         $config = $this->getConfig($this->nameRaw);
 

--- a/providers/provider-Telnyx.php
+++ b/providers/provider-Telnyx.php
@@ -50,7 +50,7 @@ class Telnyx extends providerBase
         return true;
     }
 
-    private function sendTelnyx($payload, $mid)
+    private function sendTelnyx($payload, $mid): void
     {
         $config = $this->getConfig($this->nameRaw);
 

--- a/providers/provider-Twilio.php
+++ b/providers/provider-Twilio.php
@@ -64,7 +64,7 @@ class Twilio extends providerBase
         return true;
     }
 
-    private function sendTwilio($payload, $mid)
+    private function sendTwilio($payload, $mid): void
     {
         $config = $this->getConfig($this->nameRaw);
 

--- a/providers/provider-Voipms.php
+++ b/providers/provider-Voipms.php
@@ -76,7 +76,7 @@ class Voipms extends providerBase
         return true;
     }
 
-    private function sendVoipms($payload, $from, $mid)
+    private function sendVoipms($payload, $from, $mid): void
     {
         if ((strlen($from) == 11) && (strpos($from, '1') === 0)) 
         {

--- a/providers/provider-Voxtelesys.php
+++ b/providers/provider-Voxtelesys.php
@@ -49,7 +49,7 @@ class Voxtelesys extends providerBase
         return true;
     }
 
-    private function sendVoxtelesys($payload, $mid)
+    private function sendVoxtelesys($payload, $mid): void
     {
         $config = $this->getConfig($this->nameRaw);
 


### PR DESCRIPTION
I've implemented the SMS interface for Bandwidth. 

It supports 1 on 1 sms and mms chats. Let me know if there is a way to support group messaging, I just did not see it in the other providers. 

There is an optional setting within bandwidth to supply a username and password on callback messages. This authentication is also supported within this interface via the optional 'callback_user_id' and 'callback_password' fields.

This interface does not currently listen for the callbacks that bandwidth supplies that indicate the status of a sent message. Those statuses include 'sending', 'delivered', and 'failed'. So, it is recommended that these are disabled on Bandwidth's side (via a checkbox for each type) until they are supported. Thus a message is 'delivered' when it is received at the carrier.